### PR TITLE
Don't fail on npm outdated returning 1

### DIFF
--- a/lib/poise_javascript/resources/node_package.rb
+++ b/lib/poise_javascript/resources/node_package.rb
@@ -125,7 +125,7 @@ module PoiseJavascript
           # here so you get slow behavior, sorry.
           requested_packages = Set.new(Array(resource.package_name))
           if npm_version?('>= 1.3.16') && version_data.any? {|pkg_name, _pkg_vers| requested_packages.include?(pkg_name) }
-            outdated = npm_shell_out!('outdated') || {}
+            outdated = npm_shell_out!('outdated', shellout_options: { returns: [0, 1] }) || {}
             version_data.each do |pkg_name, pkg_vers|
               pkg_vers[:candidate] = if outdated.include?(pkg_name)
                 outdated[pkg_name]['wanted']
@@ -201,7 +201,7 @@ module PoiseJavascript
         # @param args [Array<String>] Command arguments.
         # @param parse_json [Boolean] Parse the JSON on stdout.
         # @return [Hash]
-        def npm_shell_out!(subcmd, args=[], parse_json: true)
+        def npm_shell_out!(subcmd, args=[], parse_json: true, shellout_options: {})
           cmd = [new_resource.npm_binary, subcmd, '--json']
           # If path is nil, we are in global mode.
           cmd << '--global' unless new_resource.path
@@ -210,7 +210,7 @@ module PoiseJavascript
           # If we are in global mode, cwd will be nil so probably just fine. Add
           # the directory for the node binary to $PATH for post-install stuffs.
           new_path = [::File.dirname(new_resource.javascript), ENV['PATH'].to_s].join(::File::PATH_SEPARATOR)
-          out = javascript_shell_out!(cmd, cwd: new_resource.path, group: new_resource.group, user: new_resource.user, environment: {'PATH' => new_path})
+          out = javascript_shell_out!(cmd, cwd: new_resource.path, group: new_resource.group, user: new_resource.user, environment: {'PATH' => new_path}, **shellout_options)
           if parse_json
             # Parse the JSON.
             if out.stdout.strip.empty?


### PR DESCRIPTION
Simpler but bigger hammer version of #4 

Manually tested on (an old dusty corner of) my prod:
1. can downgrade npm 4.5.0 -> 4.4.0
2. can reupgrade
3. can run multiple chef runs between without panics

if @coderanger doesn't want to merge (which is legit), there is a halite built versions you can get to by sticking in your Policyfile.rb or Berksfile

```
cookbook 'poise-javascript', github: 'tulip/poise-javascript', branch: 'built'
```

I'm not particularly planning to try to keep up to date, as our chef use at tulip is (sadly) diminishing (thanks k8s)
